### PR TITLE
Connected RegisterComponent to Backend

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -36,7 +36,8 @@ export interface CleanerSetupRequest {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly BASE_URL = '/auth';
+  private readonly BASE_URL = 'http://localhost:8080/auth';
+
 
   constructor(private http: HttpClient, private router: Router) {}
 

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export type UserType = 'CLIENT' | 'CLEANER';
+
+export interface RegisterRequest {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  userType: UserType;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  userType: UserType;
+}
+
+export interface CleanerSetupRequest {
+  cleanerId: string;
+  servicesOffered: string;
+  hourlyRate: number;
+  availability: string;
+  bio: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly BASE_URL = '/auth';
+
+  constructor(private http: HttpClient, private router: Router) {}
+
+  // === REGISTER ===
+  register(data: RegisterRequest): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.BASE_URL}/register`, data);
+  }
+
+  // === LOGIN ===
+  login(data: LoginRequest): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.BASE_URL}/login`, data);
+  }
+
+  // === CLEANER SETUP ===
+  setupCleaner(data: CleanerSetupRequest): Observable<void> {
+    return this.http.post<void>(`${this.BASE_URL}/cleaner-setup`, data);
+  }
+
+  // === AUTH STORAGE ===
+  saveAuthData(res: AuthResponse): void {
+    localStorage.setItem('token', res.token);
+    localStorage.setItem('userId', res.userId);
+    localStorage.setItem('userType', res.userType);
+  }
+
+  getAuthData(): {
+    token: string | null;
+    userId: string | null;
+    userType: UserType | null;
+  } {
+    return {
+      token: localStorage.getItem('token'),
+      userId: localStorage.getItem('userId'),
+      userType: localStorage.getItem('userType') as UserType | null,
+    };
+  }
+
+  clearAuthData(): void {
+    localStorage.removeItem('token');
+    localStorage.removeItem('userId');
+    localStorage.removeItem('userType');
+  }
+
+  isLoggedIn(): boolean {
+    return !!localStorage.getItem('token');
+  }
+}

--- a/src/app/features/auth/register/register.component.ts
+++ b/src/app/features/auth/register/register.component.ts
@@ -100,10 +100,12 @@ export class RegisterComponent {
       userType: this.selectedProfileType === 'user' ? 'CLIENT' : 'CLEANER',
     };
 
+    console.log(registerData);
 
     this.authService.register(registerData).subscribe({
       next: (res) => {
         this.authService.saveAuthData(res);
+        console.log(res);
 
         if (res.userType === 'CLIENT') {
           this.router.navigate(['/register-post']);

--- a/src/app/features/auth/register/register.component.ts
+++ b/src/app/features/auth/register/register.component.ts
@@ -13,6 +13,7 @@ import { FormsModule, NgForm } from '@angular/forms';
 
 import { ToggleButtonComponent } from '../../../shared/components/toggle-button/toggle-button.component';
 import { Router } from '@angular/router';
+import {AuthService, RegisterRequest} from '../../../core/services/auth.service';
 
 @Component({
   selector: 'app-register',
@@ -29,8 +30,9 @@ export class RegisterComponent {
   constructor(
     private httpClient: HttpClient,
     private destroyRef: DestroyRef,
-    private router: Router
-  ) {}
+    private router: Router,
+    private authService: AuthService,
+) {}
 
   @ViewChildren(InputComponent) inputs!: QueryList<InputComponent>;
   @ViewChild('registerForm') registerForm!: NgForm;
@@ -54,6 +56,7 @@ export class RegisterComponent {
 
   onSubmit() {
     this.submitted = true;
+
     if (this.registerForm) {
       this.registerForm.control.markAllAsTouched();
       this.registerForm.control.markAsDirty();
@@ -89,20 +92,31 @@ export class RegisterComponent {
       return;
     }
 
-    console.log('Name:', this.formName);
-    console.log('Surname:', this.formSurname);
-    console.log('Email:', this.formEmail);
-    console.log('Password:', this.formPassword);
-    console.log('Confirm Password:', this.formConfirmPassword);
+    const registerData: RegisterRequest = {
+      firstName: this.formName.trim(),
+      lastName: this.formSurname.trim(),
+      email: this.formEmail.trim(),
+      password: this.formPassword,
+      userType: this.selectedProfileType === 'user' ? 'CLIENT' : 'CLEANER',
+    };
 
-    console.log('User Type:', this.selectedProfileType);
 
-    if (this.selectedProfileType === 'user') {
-      this.router.navigate(['/register-post']);
-    } else if (this.selectedProfileType === 'cleaner') {
-      this.router.navigate(['/cleaner-post']);
-    }
+    this.authService.register(registerData).subscribe({
+      next: (res) => {
+        this.authService.saveAuthData(res);
+
+        if (res.userType === 'CLIENT') {
+          this.router.navigate(['/register-post']);
+        } else {
+          this.router.navigate(['/cleaner-post']);
+        }
+      },
+      error: (err) => {
+        this.errorMessage = err.error?.message || 'Registration failed.';
+      },
+    });
   }
+
 
   setSelectedProfileType(event: number) {
     if (event === 0) this.selectedProfileType = 'user';


### PR DESCRIPTION
## ✨ Feature: RegisterComponent Connected to Backend

Connected the frontend registration form to the backend `/auth/register` endpoint.

### What's included:
- Sends `firstName`, `lastName`, `email`, `password`, and `userType` to backend
- Saves returned `token`, `userId`, and `userType` to localStorage
- Redirects to `/register-post` (CLIENT) or `/cleaner-post` (CLEANER)

### Notes:
- Input validation handled on frontend
- Uses `AuthService` for all communication and storage
- Assumes backend running at port 8080 with proxy or full URL setup
