### PR TITLE
Post registration connection to backend

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -11,6 +11,8 @@ export interface RegisterRequest {
   email: string;
   password: string;
   userType: UserType;
+  address: string;
+  phoneNumber: string;
 }
 
 export interface LoginRequest {
@@ -24,14 +26,16 @@ export interface AuthResponse {
   firstName: string;
   lastName: string;
   userType: UserType;
+  address: string;
+  phoneNumber: string;
 }
 
 export interface CleanerSetupRequest {
   cleanerId: string;
   servicesOffered: string;
   hourlyRate: number;
-  availability: string;
-  bio: string;
+  availability: { [day: string]: { from: string; to: string } }[];
+  bio: string[];
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/features/auth/cleaner-info/availability/availability.component.ts
+++ b/src/app/features/auth/cleaner-info/availability/availability.component.ts
@@ -23,8 +23,8 @@ export class AvailabilityComponent {
       name: 'Monday',
       shortName: 'mon',
       selected: true,
-      from: new Date(),
-      to: new Date(),
+      from: new Date(new Date().setHours(9, 0, 0, 0)),
+      to: new Date(new Date().setHours(17, 0, 0, 0)),
     },
     {
       name: 'Tuesday',
@@ -47,15 +47,23 @@ export class AvailabilityComponent {
       from: null,
       to: null,
     },
-    { name: 'Friday', shortName: 'fri', selected: true, from: null, to: null },
+    { name: 'Friday',
+      shortName: 'fri',
+      selected: false,
+      from: null,
+      to: null },
     {
       name: 'Saturday',
       shortName: 'sat',
-      selected: true,
+      selected: false,
       from: null,
       to: null,
     },
-    { name: 'Sunday', shortName: 'sun', selected: true, from: null, to: null },
+    { name: 'Sunday',
+      shortName: 'sun',
+      selected: false,
+      from: null,
+      to: null },
   ];
 
   @Output() availabilityChange = new EventEmitter<any[]>();

--- a/src/app/features/auth/cleaner-info/cleaner-info.component.html
+++ b/src/app/features/auth/cleaner-info/cleaner-info.component.html
@@ -119,25 +119,10 @@
         <p-step-panel [value]="4">
           <ng-template #content let-activateCallback="activateCallback">
             <p class="block text-gray-500 text-sm mb-8">
-              *Provide your contact details, pricing per hour, and how far from your location you are willing to work
+              *Provide pricing per hour and how far from your location you are willing to work
               (in kilometers).
             </p>
             <div class="px-8">
-              <app-input placeholder="Phone Number" name="phone-number" [required]="true" [(ngModel)]="formPhone"
-                class="mb-4" />
-              <app-input placeholder="Address" name="address" [required]="true" [(ngModel)]="formAddress"
-                class="mb-4" />
-              <div class="flex items-center gap-2 text-sm mb-4">
-                <input type="checkbox" id="acceptPolicy" name="acceptPolicy" [(ngModel)]="acceptPolicy" required
-                  class="w-4 h-4 accent-deepblue-300" />
-                <label for="acceptPolicy" class="flex items-center">
-                  Accept
-                  <a href="/privacy-policy" class="text-deepblue-300 underline ml-1" target="_blank">
-                    Privacy Policy.
-                  </a>
-                </label>
-              </div>
-
               <div class="flex gap-8 max-sm:flex-col">
                 <div class="flex items-center gap-4">
                   <p>
@@ -145,6 +130,7 @@
                   </p>
                   <app-input placeholder="BAM" name="currency" [required]="true" [(ngModel)]="formCurrency"
                     class="w-24" />
+                  <label class="-ml-2">BAM</label>
                 </div>
                 <div class="flex items-center gap-4">
                   <p>
@@ -152,6 +138,7 @@
                   </p>
                   <app-input placeholder="km" name="distance" [required]="true" [(ngModel)]="formDistance"
                     class="w-24" />
+                  <label class="-ml-2">km</label>
                 </div>
               </div>
             </div>

--- a/src/app/features/auth/cleaner-info/line-error/line-error.component.ts
+++ b/src/app/features/auth/cleaner-info/line-error/line-error.component.ts
@@ -4,6 +4,7 @@ import { Component, Input } from '@angular/core';
   selector: 'app-line-error',
   imports: [],
   templateUrl: './line-error.component.html',
+  standalone: true
 })
 export class LineErrorComponent {
   @Input({ required: true }) error: string = ''; // Error message to display

--- a/src/app/features/auth/register/register.component.html
+++ b/src/app/features/auth/register/register.component.html
@@ -13,6 +13,10 @@
 
     <app-input placeholder="Email" name="formEmail" [required]="true" [(ngModel)]="formEmail" />
 
+    <app-input placeholder="Address" name="formAddress" [required]="true" [(ngModel)]="formAddress" />
+
+    <app-input placeholder="Phone number" name="formPhoneNumber" [required]="true" [(ngModel)]="formPhoneNumber" />
+
     <div class="relative">
       <app-input placeholder="Password" name="formPassword" [required]="true" [(ngModel)]="formPassword"
         [type]="showPassword ? 'text' : 'password'" />

--- a/src/app/features/auth/register/register.component.html
+++ b/src/app/features/auth/register/register.component.html
@@ -4,14 +4,19 @@
       <app-toggle-button [options]="['User', 'Cleaner']" (toggleUserType)="setSelectedProfileType($event)" />
     </div>
 
-    <div class="flex flex-col items-center gap-2">
-      <input type="file" id="fileInput" class="hidden" (change)="onFileSelected($event)" />
-      <label for="fileInput"
-             class="cursor-pointer bg-deepblue-200 text-gray-600 w-24 h-24 rounded-full flex items-center justify-center">
-        Add Photo
-      </label>
-      <img *ngIf="selectedImageUrl" [src]="selectedImageUrl" class="w-16 h-16 rounded-full object-cover" alt="Preview" />
-    </div>
+
+<!--    NASTIMAJ DA NE GURA SVE VAN OKVIRA POROZRA, msm da je overflow neki hidden ili nesto - logika je ok-->
+
+<!--    <div class="flex flex-col items-center gap-2">-->
+<!--      <input type="file" id="fileInput" class="hidden" (change)="onFileSelected($event)" />-->
+<!--      <label for="fileInput"-->
+<!--             class="cursor-pointer bg-deepblue-200 text-gray-600 w-24 h-24 rounded-full flex items-center justify-center">-->
+<!--        Add Photo-->
+<!--      </label>-->
+<!--      <img *ngIf="selectedImageUrl" [src]="selectedImageUrl" class="w-16 h-16 rounded-full object-cover" alt="Preview" />-->
+<!--    </div>-->
+
+
 
 
     <div class="flex gap-8 max-md:gap-2">

--- a/src/app/features/auth/register/register.component.html
+++ b/src/app/features/auth/register/register.component.html
@@ -4,6 +4,15 @@
       <app-toggle-button [options]="['User', 'Cleaner']" (toggleUserType)="setSelectedProfileType($event)" />
     </div>
 
+    <div class="flex flex-col items-center gap-2">
+      <input type="file" id="fileInput" class="hidden" (change)="onFileSelected($event)" />
+      <label for="fileInput"
+             class="cursor-pointer bg-deepblue-200 text-gray-600 w-24 h-24 rounded-full flex items-center justify-center">
+        Add Photo
+      </label>
+      <img *ngIf="selectedImageUrl" [src]="selectedImageUrl" class="w-16 h-16 rounded-full object-cover" alt="Preview" />
+    </div>
+
 
     <div class="flex gap-8 max-md:gap-2">
       <app-input placeholder="Name" name="formName" [required]="true" [(ngModel)]="formName" />

--- a/src/app/features/auth/register/register.component.ts
+++ b/src/app/features/auth/register/register.component.ts
@@ -52,6 +52,8 @@ export class RegisterComponent {
 
   submitted = false;
 
+  selectedImageUrl: string | null = null;
+
   toggleShowPassword() {
     this.showPassword = !this.showPassword;
   }
@@ -123,6 +125,11 @@ export class RegisterComponent {
         this.errorMessage = err.error?.message || 'Registration failed.';
       },
     });
+
+    // NOTE: selectedImageUrl trenutno se koristi samo za prikaz preview slike.
+    // Kada se bude spajalo sa backendom, potrebno je:
+    // 1. uploadati na storage (Heroku??) i čuvati URL u bazi.
+
   }
 
 
@@ -134,5 +141,17 @@ export class RegisterComponent {
   private isValidEmail(email: string): boolean {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailPattern.test(email);
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files[0]) {
+      const file = input.files[0];
+      const reader = new FileReader();
+      reader.onload = () => {
+        this.selectedImageUrl = reader.result as string;
+      };
+      reader.readAsDataURL(file);
+    }
   }
 }

--- a/src/app/features/auth/register/register.component.ts
+++ b/src/app/features/auth/register/register.component.ts
@@ -40,6 +40,8 @@ export class RegisterComponent {
   formName: string = '';
   formSurname: string = '';
   formEmail: string = '';
+  formAddress: string = '';
+  formPhoneNumber: string = '';
   formPassword: string = '';
   formConfirmPassword: string = '';
 
@@ -70,6 +72,8 @@ export class RegisterComponent {
       !this.formName.trim() ||
       !this.formSurname.trim() ||
       !this.formEmail.trim() ||
+      !this.formAddress.trim() ||
+      !this.formPhoneNumber.trim() ||
       !this.formPassword.trim() ||
       !this.formConfirmPassword.trim()
     ) {
@@ -96,6 +100,8 @@ export class RegisterComponent {
       firstName: this.formName.trim(),
       lastName: this.formSurname.trim(),
       email: this.formEmail.trim(),
+      address: this.formAddress.trim(),
+      phoneNumber: this.formPhoneNumber.trim(),
       password: this.formPassword,
       userType: this.selectedProfileType === 'user' ? 'CLIENT' : 'CLEANER',
     };
@@ -108,7 +114,7 @@ export class RegisterComponent {
         console.log(res);
 
         if (res.userType === 'CLIENT') {
-          this.router.navigate(['/register-post']);
+          this.router.navigate(['/dashboard/user']);
         } else {
           this.router.navigate(['/cleaner-post']);
         }

--- a/src/app/features/auth/user-info/user-info.component.html
+++ b/src/app/features/auth/user-info/user-info.component.html
@@ -19,17 +19,6 @@
       class="!flex-0" />
 
 
-    <div class="flex items-center gap-2 text-sm">
-      <input type="checkbox" id="acceptPolicy" name="acceptPolicy" [(ngModel)]="acceptPolicy" required
-        class="w-4 h-4 accent-deepblue-300" />
-      <label for="acceptPolicy" class="flex items-center">
-        Accept
-        <a href="/privacy-policy" class="text-deepblue-300 underline ml-1" target="_blank">
-          Privacy Policy.
-        </a>
-      </label>
-    </div>
-
     <div class="text-center">
       <app-button type="submit">Finish</app-button>
     </div>

--- a/src/app/features/auth/user-info/user-info.component.ts
+++ b/src/app/features/auth/user-info/user-info.component.ts
@@ -39,7 +39,6 @@ export class UserInfoComponent {
     console.log(this.formSurname);
     console.log(this.formPhoneNumber);
     console.log(this.formAddress);
-    console.log(this.acceptPolicy);
 
     this.router.navigate(['/dashboard/user']);
   }

--- a/src/app/features/auth/user-info/user-info.component.ts
+++ b/src/app/features/auth/user-info/user-info.component.ts
@@ -20,7 +20,6 @@ export class UserInfoComponent {
   formSurname: string = '';
   formPhoneNumber: string = '';
   formAddress: string = '';
-  acceptPolicy: boolean = false;
 
   onSubmit() {
     if (this.registerForm) {

--- a/src/app/features/cleaner/cleaner-page/cleaner-page.component.ts
+++ b/src/app/features/cleaner/cleaner-page/cleaner-page.component.ts
@@ -11,15 +11,14 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-cleaner-page',
   templateUrl: './cleaner-page.component.html',
-  standalone: true,  // If you're using standalone components
+  standalone: true,
   imports: [
     CommonModule,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-
-     DateSelectorComponent,
+    DateSelectorComponent,
     TimeSelectorComponent
   ]
 })

--- a/src/app/features/home/home-page/home-page.component.ts
+++ b/src/app/features/home/home-page/home-page.component.ts
@@ -12,7 +12,6 @@ import { FooterComponent } from '../../../shared/footer/footer/footer.component'
   standalone: true,
   imports: [
     RouterModule,
-    ContainerComponent,
     ButtonComponent,
     NavbarComponent,
     HeroSectionComponent,

--- a/src/app/shared/navbar/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar/navbar.component.ts
@@ -5,7 +5,7 @@ import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-navbar',
-  imports: [ContainerComponent, ButtonComponent, RouterModule],
+  imports: [ButtonComponent, RouterModule],
   templateUrl: './navbar.component.html',
   standalone: true,
 })


### PR DESCRIPTION
## ✅ Frontend - Post Registration Implementation

### Description:

Full post-registration logic implemented for both user types (**CLIENT** and **CLEANER**):

- `address` and `phoneNumber` fields added directly to the registration form (instead of a separate post-registration form for CLIENT)

### After successful registration:
- **CLIENT** is redirected directly to `/dashboard/user`
- **CLEANER** is redirected to `/cleaner-post` (step-by-step form)

### Cleaner post-registration implemented in 4 steps:
1. Service selection
2. Service description
3. Availability definition
4. Pricing setup and terms acceptance

- All validations and UX steps are handled locally, without image upload or backend communication
- Image upload is to be implemented on the frontend (URL is stored), but not yet sent to the backend (**TODO**)

### Comment:
- Cleaner `availability` is stored as a `List<Map<String, TimeRange>>`
- Cleaner `bio` is stored as `List<String>` (based on service descriptions)
- User authentication is already handled, and the `userId` from `AuthResponse` is used for the setup
