### PR TITLE
Implement Editable Universal Profile Page with Modular Components

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,6 +18,8 @@ import { NotificationsComponent } from './features/notifications/notifications.c
 
 import { TermsAndConditionsComponent } from './features/terms-and-conditions/terms-and-conditions.component';
 import { PlatformLayoutComponent } from './shared/components/platform-layout/platform-layout.component';
+import { SharedProfileComponent } from './features/shared-profile/shared-profile.component';
+import { CleanerProfilePublicComponent } from './features/cleaner-profile-public/cleaner-profile-public.component';
 
 export const routes: Routes = [
   {
@@ -36,6 +38,10 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'yuki',
+    component: CleanerProfilePublicComponent,
+  },
+  {
     path: '',
     component: PlatformLayoutComponent,
     children: [
@@ -43,7 +49,11 @@ export const routes: Routes = [
         path: 'user',
         children: [
           { path: 'dashboard', component: UserDashboardComponent },
-          { path: 'profile', component: HomePageComponent },
+          {
+            path: 'profile',
+            component: SharedProfileComponent,
+            data: { userType: 'CLIENT' },
+          },
           { path: 'reservations', component: HomePageComponent },
           { path: 'favorites', component: HomePageComponent },
           { path: 'payments', component: HomePageComponent },
@@ -55,7 +65,12 @@ export const routes: Routes = [
         path: 'cleaner',
         children: [
           { path: 'dashboard', component: CleanerDashboardComponent },
-          { path: 'profile', component: HomePageComponent },
+          {
+            path: 'profile',
+            component: SharedProfileComponent,
+            data: { userType: 'CLIENT' },
+          },
+
           { path: 'jobs', component: HomePageComponent },
           { path: 'services', component: HomePageComponent },
           { path: 'availability', component: HomePageComponent },

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -105,7 +105,7 @@ export class AuthService {
 
     // Mock fallback for development
     if (!role) {
-      return 'CLEANER'; // or 'CLEANER' if you're working on that flow
+      return 'CLIENT'; // or 'CLEANER' if you're working on that flow
     }
 
     return role;

--- a/src/app/features/shared-profile/profile-address-card/profile-address-card.component.html
+++ b/src/app/features/shared-profile/profile-address-card/profile-address-card.component.html
@@ -1,0 +1,41 @@
+<div class="flex justify-between items-center">
+  <h3 class="font-semibold text-gray-800">Address</h3>
+  <div class="space-x-2">
+    <button *ngIf="!isEditing" (click)="onToggleEdit.emit()"
+      class="text-sm text-gray-600 border px-3 py-1 rounded-lg hover:bg-gray-100">
+      Edit ✎
+    </button>
+    <button *ngIf="isEditing" (click)="onSave.emit()"
+      class="text-sm text-white bg-blue-600 px-3 py-1 rounded-lg hover:bg-blue-700">
+      Save
+    </button>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <ng-container *ngIf="isEditing; else viewBlock">
+    <input [(ngModel)]="profile.country" class="border px-2 py-1 rounded w-full" placeholder="Country" />
+    <input [(ngModel)]="profile.city" class="border px-2 py-1 rounded w-full" placeholder="City" />
+    <input [(ngModel)]="profile.street" class="border px-2 py-1 rounded w-full" placeholder="Street" />
+    <input [(ngModel)]="profile.streetExtra" class="border px-2 py-1 rounded w-full" placeholder="Extra Details" />
+  </ng-container>
+
+  <ng-template #viewBlock>
+    <div>
+      <p class="text-sm text-gray-500">Country</p>
+      <p>{{ profile.country }}</p>
+    </div>
+    <div>
+      <p class="text-sm text-gray-500">City</p>
+      <p>{{ profile.city }}</p>
+    </div>
+    <div>
+      <p class="text-sm text-gray-500">Street Name</p>
+      <p>{{ profile.street }}</p>
+    </div>
+    <div>
+      <p class="text-sm text-gray-500">Street Number / Floor</p>
+      <p>{{ profile.streetExtra }}</p>
+    </div>
+  </ng-template>
+</div>

--- a/src/app/features/shared-profile/profile-address-card/profile-address-card.component.ts
+++ b/src/app/features/shared-profile/profile-address-card/profile-address-card.component.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-profile-address-card',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './profile-address-card.component.html',
+})
+export class ProfileAddressCardComponent {
+  @Input() profile: any;
+  @Input() isEditing: boolean = false;
+  @Output() onToggleEdit = new EventEmitter<void>();
+  @Output() onSave = new EventEmitter<void>();
+}

--- a/src/app/features/shared-profile/profile-overview-card/profile-overview-card.component.html
+++ b/src/app/features/shared-profile/profile-overview-card/profile-overview-card.component.html
@@ -1,0 +1,27 @@
+<div class="flex items-center gap-6 w-full sm:w-auto">
+  <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center text-sm text-gray-600">
+    Add Profile Photo
+  </div>
+  <div class="space-y-1 w-full">
+    <ng-container *ngIf="isEditing; else viewBlock">
+      <input [(ngModel)]="profile.firstName" class="border px-2 py-1 rounded w-full" placeholder="First Name" />
+      <input [(ngModel)]="profile.lastName" class="border px-2 py-1 rounded w-full" placeholder="Last Name" />
+      <input [(ngModel)]="profile.address" class="border px-2 py-1 rounded w-full" placeholder="Address" />
+    </ng-container>
+    <ng-template #viewBlock>
+      <p class="text-lg font-semibold">{{ profile.firstName }} {{ profile.lastName }}</p>
+      <p class="text-gray-500">{{ profile.address }}</p>
+    </ng-template>
+  </div>
+</div>
+
+<div class="flex justify-end w-full sm:w-auto space-x-2">
+  <button *ngIf="!isEditing" (click)="onToggleEdit.emit()"
+    class="text-sm text-gray-600 border px-3 py-1 rounded-lg hover:bg-gray-100">
+    Edit ✎
+  </button>
+  <button *ngIf="isEditing" (click)="onSave.emit()"
+    class="text-sm text-white bg-blue-600 px-3 py-1 rounded-lg hover:bg-blue-700">
+    Save
+  </button>
+</div>

--- a/src/app/features/shared-profile/profile-overview-card/profile-overview-card.component.ts
+++ b/src/app/features/shared-profile/profile-overview-card/profile-overview-card.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-profile-overview-card',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './profile-overview-card.component.html',
+})
+export class ProfileOverviewCardComponent {
+  @Input() profile: any;
+  @Input() isEditing: boolean = false;
+  @Output() onToggleEdit = new EventEmitter<void>();
+  @Output() onSave = new EventEmitter<void>();
+}

--- a/src/app/features/shared-profile/profile-personal-card/profile-personal-card.component.html
+++ b/src/app/features/shared-profile/profile-personal-card/profile-personal-card.component.html
@@ -1,0 +1,27 @@
+<div class="flex justify-between items-center">
+  <h3 class="font-semibold text-gray-800">Personal Information</h3>
+  <div class="space-x-2">
+    <button *ngIf="!isEditing" (click)="onToggleEdit.emit()"
+      class="text-sm text-gray-600 border px-3 py-1 rounded-lg hover:bg-gray-100">
+      Edit ✎
+    </button>
+    <button *ngIf="isEditing" (click)="onSave.emit()"
+      class="text-sm text-white bg-blue-600 px-3 py-1 rounded-lg hover:bg-blue-700">
+      Save
+    </button>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <ng-container *ngFor="let field of personalFields">
+    <div>
+      <p class="text-sm text-gray-500">{{ field.label }}</p>
+      <ng-container *ngIf="isEditing; else view">
+        <input [(ngModel)]="profile[field.key]" class="border px-2 py-1 rounded w-full" />
+      </ng-container>
+      <ng-template #view>
+        <p>{{ profile[field.key] }}</p>
+      </ng-template>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/features/shared-profile/profile-personal-card/profile-personal-card.component.ts
+++ b/src/app/features/shared-profile/profile-personal-card/profile-personal-card.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-profile-personal-card',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './profile-personal-card.component.html',
+  standalone: true,
+})
+export class ProfilePersonalCardComponent {
+  personalFields = [
+    { label: 'First Name', key: 'firstName' },
+    { label: 'Last Name', key: 'lastName' },
+    { label: 'Email', key: 'email' },
+    { label: 'Phone', key: 'phone' },
+  ];
+
+  @Input() profile: any;
+  @Input() isEditing: boolean = false;
+  @Output() onToggleEdit = new EventEmitter<void>();
+  @Output() onSave = new EventEmitter<void>();
+}

--- a/src/app/features/shared-profile/shared-profile.component.html
+++ b/src/app/features/shared-profile/shared-profile.component.html
@@ -1,0 +1,27 @@
+<div class="flex flex-col gap-4">
+
+
+
+  <!-- Personal Info -->
+  <!-- <div class="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+    <app-profile-personal-card [profile]="profile" [isEditing]="isEditingPersonal"
+      (onToggleEdit)="toggleEdit('personal')" (onSave)="saveProfile('personal')" />
+  </div> -->
+  <app-gray-card>
+    <app-profile-overview-card [profile]="profile" [isEditing]="isEditingOverview"
+      (onToggleEdit)="toggleEdit('overview')" (onSave)="saveProfile('overview')" />
+  </app-gray-card>
+
+  <app-gray-card>
+
+    <app-profile-personal-card [profile]="profile" [isEditing]="isEditingPersonal"
+      (onToggleEdit)="toggleEdit('personal')" (onSave)="saveProfile('personal')" />
+  </app-gray-card>
+
+  <app-gray-card>
+    <app-profile-address-card [profile]="profile" [isEditing]="isEditingAddress" (onToggleEdit)="toggleEdit('address')"
+      (onSave)="saveProfile('address')" />
+  </app-gray-card>
+
+
+</div>

--- a/src/app/features/shared-profile/shared-profile.component.ts
+++ b/src/app/features/shared-profile/shared-profile.component.ts
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { UserType } from '../../core/services/auth.service';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { EditableFieldComponent } from '../../shared/components/editable-field/editable-field.component';
+import { ProfileOverviewCardComponent } from './profile-overview-card/profile-overview-card.component';
+import { ProfilePersonalCardComponent } from './profile-personal-card/profile-personal-card.component';
+import { ProfileAddressCardComponent } from './profile-address-card/profile-address-card.component';
+import { GrayCardComponent } from '../../shared/components/gray-card/gray-card.component';
+
+@Component({
+  selector: 'app-shared-profile',
+  imports: [
+    CommonModule,
+    FormsModule,
+    EditableFieldComponent,
+    ProfileOverviewCardComponent,
+    ProfilePersonalCardComponent,
+    ProfileAddressCardComponent,
+    GrayCardComponent,
+  ],
+  templateUrl: './shared-profile.component.html',
+  standalone: true,
+})
+export class SharedProfileComponent {
+  userType!: UserType;
+  isEditingPersonal = false;
+  isEditingOverview = false;
+  isEditingAddress = false;
+
+  profile = {
+    firstName: 'Neko ime',
+    lastName: 'Neko prezime',
+    email: 'email@email.com',
+    phone: '+387 61 111 222',
+    address: 'Sarajevo 123',
+    country: 'Bosna i Hercegovina',
+    city: 'Sarajevo',
+    street: 'Mula Mustafe Bašeskije',
+    streetExtra: '25, floor 4',
+  };
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    const type = this.route.snapshot.data['userType'];
+    this.userType = type;
+  }
+
+  toggleEdit(section: 'overview' | 'personal' | 'address') {
+    if (section === 'overview')
+      this.isEditingOverview = !this.isEditingOverview;
+    if (section === 'personal')
+      this.isEditingPersonal = !this.isEditingPersonal;
+    if (section === 'address') this.isEditingAddress = !this.isEditingAddress;
+  }
+
+  saveProfile(section: 'overview' | 'personal' | 'address') {
+    if (section === 'overview') this.isEditingOverview = false;
+    if (section === 'personal') this.isEditingPersonal = false;
+    if (section === 'address') this.isEditingAddress = false;
+
+    console.log(`Saved ${section} data:`, this.profile);
+  }
+}

--- a/src/app/shared/components/editable-field/editable-field.component.html
+++ b/src/app/shared/components/editable-field/editable-field.component.html
@@ -1,0 +1,12 @@
+<!-- app-editable-field.component.html -->
+<div class="space-y-1 w-full">
+  <label class="text-sm text-gray-500">{{ label }}</label>
+
+  <ng-container *ngIf="editMode; else viewMode">
+    <input [(ngModel)]="model" class="border px-2 py-1 rounded w-full" [placeholder]="label" />
+  </ng-container>
+
+  <ng-template #viewMode>
+    <p class="text-gray-800">{{ model }}</p>
+  </ng-template>
+</div>

--- a/src/app/shared/components/editable-field/editable-field.component.ts
+++ b/src/app/shared/components/editable-field/editable-field.component.ts
@@ -1,0 +1,16 @@
+// app-editable-field.component.ts
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-editable-field',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './editable-field.component.html',
+})
+export class EditableFieldComponent {
+  @Input() label: string = '';
+  @Input() editMode: boolean = false;
+  @Input() model!: string;
+}

--- a/src/app/shared/components/gray-card/gray-card.component.html
+++ b/src/app/shared/components/gray-card/gray-card.component.html
@@ -1,0 +1,3 @@
+<div class="rounded-xl border border-gray-200 p-6 space-y-4">
+  <ng-content />
+</div>

--- a/src/app/shared/components/gray-card/gray-card.component.ts
+++ b/src/app/shared/components/gray-card/gray-card.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-gray-card',
+  imports: [],
+  templateUrl: './gray-card.component.html',
+  standalone: true,
+})
+export class GrayCardComponent {}


### PR DESCRIPTION
### ✨ What's Implemented
- Extracted profile page into three reusable components:
  - `ProfileOverviewCardComponent`
  - `ProfilePersonalCardComponent`
  - `ProfileAddressCardComponent`
- Implemented full edit & save functionality for each section using controlled `editMode` flags

### ✅ Features
- Profile photo/name/address: editable inline
- Personal information (first name, last name, email, phone): editable with toggle
- Address fields (country, city, street, extra): fully editable
- Save buttons instantly update the local state and reflect changes in UI

### 💡 Design Principles
- Standalone, modular components
- Clean two-way binding with `[(ngModel)]`
- Tailwind styling retained exactly as in original design

### 📍 Routes Tested
- `/user/profile`
- `/cleaner/profile`

### 🧪 How to Test
- Open either profile route
- Edit any section using ✎
- Save and ensure content updates live

This sets a solid foundation for integrating backend persistence next. 🔥
